### PR TITLE
graphql playground middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,5 +8,6 @@
                  [metosin/ring-http-response "0.9.0"]
                  [ring/ring-core "1.6.0"]
                  [threatgrid/ring-graphiql "0.1.1"]
-                 [threatgrid/ring-graphql-voyager "0.1.2"]]
+                 [threatgrid/ring-graphql-voyager "0.1.2"]
+                 [viebel/ring-graphql-playground "0.1.1"]]
   :profiles {:test {:dependencies [[ring/ring-mock "0.3.0"]]}})

--- a/src/ring_graphql_ui/core.clj
+++ b/src/ring_graphql_ui/core.clj
@@ -94,7 +94,7 @@
 
 (defn voyager
   "Returns a Ring handler which can be used to serve GraphQL Voyager"
-  ([] (graphiql {}))
+  ([] (voyager {}))
   ([options]
    (serve-ui {:path "/voyager"
               :root "graphql-voyager"}
@@ -107,3 +107,21 @@
    (wrap-ui handler voyager))
   ([handler options]
    (wrap-ui handler voyager options)))
+
+;;-------- GraphQL Playground
+
+(defn playground
+  "Returns a Ring handler which can be used to serve GraphQL Playground https://github.com/prisma-labs/graphql-playground#as-html-page"
+  ([] (playground {}))
+  ([options]
+   (serve-ui {:path "/playground"
+              :root "graphql-playground"}
+             options
+             "GRAPHQL_PLAYGROUND_CONF")))
+
+(defn wrap-playground
+  "Middleware to serve GraphQL Playground."
+  ([handler]
+   (wrap-ui handler playground))
+  ([handler options]
+   (wrap-ui handler playground options)))

--- a/test/ring_graphql_ui/core_test.clj
+++ b/test/ring_graphql_ui/core_test.clj
@@ -99,3 +99,23 @@
                                         :endpoint "ctia/graphql"}))]
     (is (html? (http-get handler "/voyager/index.html")))
     (is (nil? (http-get handler "unknown")))))
+
+(deftest playground-test
+  (let [handler (sut/playground {:path "/playground"
+                                 :endpoint "ctia/graphql"})]
+    (testing "index.html"
+      (is (redirect? (http-get handler "/playground")))
+      (is (html? (http-get handler "/playground/index.html"))))
+    (testing "conf.js"
+      (let [conf-response (http-get handler "/playground/conf.js")]
+        (is (javascript? conf-response))
+        (is (= {:endpoint "ctia/graphql"}
+               (read-js (:body conf-response)
+                        "GRAPHQL_PLAYGROUND_CONF")))))))
+
+(deftest wrap-playground-test
+  (let [handler (-> (constantly nil)
+                    (sut/wrap-graphiql {:path "/playground"
+                                        :endpoint "ctia/graphql"}))]
+    (is (html? (http-get handler "/playground/index.html")))
+    (is (nil? (http-get handler "unknown")))))


### PR DESCRIPTION
Add a middleware to server another graphql IDE, namely [https://github.com/prisma-labs/graphql-playground/](graphql-playground)